### PR TITLE
getOriginal issue with Model Observers

### DIFF
--- a/src/Carbonated.php
+++ b/src/Carbonated.php
@@ -255,7 +255,7 @@ trait Carbonated
 
         // Create Carbon instances.
         foreach ($fieldFormats as $field => $format) {
-            $value = $this->getOriginal($field);
+            $value = $this->attributes[$field];
             $carbonInstance = $value ? Carbon::createFromFormat($format, $value, $databaseTimezone) : null;
             $carbonInstances[$field] = $carbonInstance ? $carbonInstance->timezone($carbonatedTimezone) : null;
         }


### PR DESCRIPTION
By using 'getOriginal' on the attribute, you make records accessed within Model Observer Scopes dependant on the dates being there previously.  It would be better to get the value directly from the attributes to ensure the most up to date value for any dates run through the trait.